### PR TITLE
chore: fix release workflow, bump to 0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,12 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  release:
+  release-pr:
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.event.head_commit.message, 'release:') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,23 +49,52 @@ jobs:
           # Extract content between first ## vX.Y.Z and next ## heading
           awk '/^## v/{if(found)exit; found=1; next} found' CHANGELOG.md > /tmp/release-notes.md
 
-      - name: Commit and tag
-        if: steps.check.outputs.has_unreleased == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "release: ${{ steps.bump.outputs.version }}"
-          TAG="$(date -u +%Y-%m-%dT%H%M%SZ)"
-          git tag "$TAG"
-          git push origin main --tags
-
-      - name: Create GitHub release
+      - name: Create release PR
         if: steps.check.outputs.has_unreleased == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="$(git describe --tags --abbrev=0)"
-          gh release create "$TAG" \
-            --title "${{ steps.bump.outputs.version }}" \
+          BRANCH="release/${{ steps.bump.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "release: ${{ steps.bump.outputs.version }}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "release: ${{ steps.bump.outputs.version }}" \
+            --body "$(cat /tmp/release-notes.md)" \
+            --base main \
+            --head "$BRANCH"
+
+  tag-release:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.event.head_commit.message, 'release:') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version and tag
+        id: version
+        run: |
+          VERSION=$(echo "${{ github.event.head_commit.message }}" | sed 's/release: //')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          TAG="$(date -u +%Y-%m-%dT%H%M%SZ)"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog
+        run: |
+          awk '/^## v/{if(found)exit; found=1; next} found' CHANGELOG.md > /tmp/release-notes.md
+
+      - name: Create tag and GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.version }}" \
             --notes-file /tmp/release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## Unreleased
-<!-- bump: minor -->
+## 0.3.0
 
 ### Added
 - Controller UI v0.3: event log panel with color-coded icons, auto-scroll, and pause indicator

--- a/agent-runtime/pyproject.toml
+++ b/agent-runtime/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-runtime"
-version = "0.2.0"
+version = "0.3.0"
 description = "Agent bootstrap and lifecycle management for MCP Mesh"
 requires-python = ">=3.12"
 dependencies = []

--- a/mesh-server/pyproject.toml
+++ b/mesh-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mesh-server"
-version = "0.1.0"
+version = "0.3.0"
 description = "MCP Mesh Server — event-sourced message-passing actor system"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Collapse `## Unreleased` into `## 0.3.0` in CHANGELOG.md — stops release workflow from triggering
- Bump both `mesh-server` and `agent-runtime` versions to 0.3.0
- Fix release workflow: creates a PR instead of pushing directly to main (which branch protection blocks)
- Add `tag-release` job that tags and creates a GitHub release when a release PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)