### PR TITLE
feat: XOR-derived filesystem channels for attachments (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## Unreleased
 <!-- bump: patch -->
 
+### Added
+- New `channels/` subsystem: XOR-derived filesystem channels for attachment exchange between agents
+- `resolve_channel` MCP tool (#7): returns deterministic shared directory path for file exchange
+- `attachments` parameter on `send()` tool: typed attachment descriptors (inline or file-ref)
+- `attachments` field in `read_inbox()` response: resolved absolute paths for file-ref attachments
+- `channels/SPEC.md` with 6 invariants and 1 failure mode
+- Attachment validation: type field required, path traversal (`..`) rejected
+- Backward-compatible event replay: old events without `attachments` field replay with `None`
+
 ### Changed
 - CI: split monolithic job into parallel lint, test, smoke, version-check jobs
 - CI: pin Python 3.13, bump `requires-python` to `>=3.13` in both packages

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ uv run mesh-server
 | mesh-server | `mesh-server/` | Singleton MCP server: message routing, agent lifecycle, event store |
 | controller-ui | `mesh-server/src/mesh_server/static/` | Web UI for traffic monitoring, agent management, send/receive |
 | agent-runtime | `agent-runtime/` | Agent bootstrap, UUID assignment, MCP connection, lifecycle |
-| channels | *(planned)* | XOR-derived filesystem channels for attachments and shared artifacts |
+| channels | `channels/` | XOR-derived filesystem channels for attachments and shared artifacts |
 
 ## Development
 

--- a/channels/SPEC.md
+++ b/channels/SPEC.md
@@ -1,0 +1,44 @@
+# channels Subsystem Specification
+
+## Purpose
+
+XOR-derived filesystem channels for attachment exchange between mesh agents. Provides deterministic shared directories computed from participant UUIDs.
+
+## Public Interface
+
+| Function | Description |
+|---|---|
+| `resolve_channel(mesh_dir, participants)` | Compute XOR path, create dir, return `{channel_dir, attachments_dir}` |
+| `ensure_channel_dir(channel_dir)` | Create channel dir with `attachments/` subdirectory |
+| `xor_uuids(uuids)` | XOR sorted UUIDs as 128-bit ints, return full UUID string |
+
+## Invariants
+
+- **CH-INV-1**: XOR of two UUIDs is symmetric — `XOR(A,B) == XOR(B,A)`
+- **CH-INV-2**: XOR of three+ UUIDs is associative — order-independent
+- **CH-INV-3**: XOR result is a valid full UUID string (8-4-4-4-12 hex)
+- **CH-INV-4**: Broadcast UUID resolves to `.mesh/channels/all/`
+- **CH-INV-5**: `ensure_channel_dir` creates directory with `attachments/` subdirectory
+- **CH-INV-6**: `resolve_channel` computes XOR path and creates directory lazily
+
+## Failure Modes
+
+- **CH-FAIL-1**: `resolve_channel` with fewer than 2 participants raises ValueError
+
+## Filesystem Layout
+
+```
+.mesh/
+  channels/
+    <xor-uuid>/           <- XOR-derived pair/group channel
+      attachments/
+    all/                  <- well-known broadcast channel
+      attachments/
+```
+
+## Properties
+
+- **Symmetric**: `XOR(A,B) = XOR(B,A)` — both parties compute the same directory
+- **Associative**: `XOR(A,B,C)` = same regardless of grouping
+- **Deterministic**: No coordination or lookup needed
+- **Standalone**: No imports from mesh-server or agent-runtime

--- a/channels/pyproject.toml
+++ b/channels/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "channels"
+version = "0.4.0"
+description = "XOR-derived filesystem channels for MCP Mesh"
+requires-python = ">=3.13"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/channels"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+]

--- a/channels/src/channels/__init__.py
+++ b/channels/src/channels/__init__.py
@@ -1,0 +1,54 @@
+"""XOR-derived filesystem channels for MCP Mesh.
+
+Public API:
+    resolve_channel(mesh_dir, participants) -> dict
+    ensure_channel_dir(channel_dir) -> None
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from channels.xor import xor_uuids
+
+BROADCAST_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def ensure_channel_dir(channel_dir: Path) -> None:
+    """Create a channel directory with an attachments/ subdirectory."""
+    channel_dir.mkdir(parents=True, exist_ok=True)
+    (channel_dir / "attachments").mkdir(exist_ok=True)
+
+
+def resolve_channel(
+    *,
+    mesh_dir: Path,
+    participants: list[str],
+) -> dict:
+    """Resolve the channel directory for a set of participants.
+
+    If any participant is the broadcast UUID, returns the well-known
+    .mesh/channels/all/ path. Otherwise computes XOR(sorted(participants))
+    and returns that as the channel directory name.
+
+    Creates the directory (with attachments/ subdirectory) if it doesn't exist.
+
+    Raises ValueError if fewer than 2 participants are provided.
+    """
+    if len(participants) < 2:
+        raise ValueError("Need at least 2 participants for a channel")
+
+    channels_root = mesh_dir / "channels"
+
+    if BROADCAST_UUID in participants:
+        channel_dir = channels_root / "all"
+    else:
+        xor_id = xor_uuids(participants)
+        channel_dir = channels_root / xor_id
+
+    ensure_channel_dir(channel_dir)
+
+    return {
+        "channel_dir": str(channel_dir),
+        "attachments_dir": str(channel_dir / "attachments"),
+    }

--- a/channels/src/channels/xor.py
+++ b/channels/src/channels/xor.py
@@ -1,0 +1,23 @@
+"""XOR computation on UUIDs for channel resolution."""
+
+from __future__ import annotations
+
+import uuid as uuid_mod
+
+
+def xor_uuids(uuids: list[str]) -> str:
+    """Compute XOR of sorted UUIDs, return as UUID string.
+
+    Each UUID is parsed as a 128-bit integer. The sorted list is
+    XORed left-to-right. The result is formatted as a standard
+    UUID string (8-4-4-4-12 hex).
+    """
+    if not uuids:
+        raise ValueError("Need at least one UUID")
+
+    sorted_uuids = sorted(uuids)
+    result = 0
+    for u in sorted_uuids:
+        result ^= uuid_mod.UUID(u).int
+
+    return str(uuid_mod.UUID(int=result))

--- a/channels/tests/test_channels.py
+++ b/channels/tests/test_channels.py
@@ -1,0 +1,70 @@
+"""Tests for channel directory resolution and management."""
+
+import pytest
+
+from channels import resolve_channel, ensure_channel_dir
+from channels.xor import xor_uuids
+
+BROADCAST_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def test_inv4_broadcast_resolves_to_all(tmp_path):  # Tests CH-INV-4
+    """Broadcast UUID resolves to .mesh/channels/all/."""
+    mesh_dir = tmp_path / ".mesh"
+    result = resolve_channel(
+        mesh_dir=mesh_dir,
+        participants=["agent-a", BROADCAST_UUID],
+    )
+    assert result["channel_dir"] == str(mesh_dir / "channels" / "all")
+    assert result["attachments_dir"] == str(
+        mesh_dir / "channels" / "all" / "attachments"
+    )
+
+
+def test_inv5_ensure_creates_directory(tmp_path):  # Tests CH-INV-5
+    """ensure_channel_dir creates channel dir with attachments/ subdirectory."""
+    channel_dir = tmp_path / "channels" / "test-channel"
+    ensure_channel_dir(channel_dir)
+    assert channel_dir.is_dir()
+    assert (channel_dir / "attachments").is_dir()
+
+
+def test_inv6_resolve_returns_paths(tmp_path):  # Tests CH-INV-6
+    """resolve_channel returns channel_dir and attachments_dir."""
+    mesh_dir = tmp_path / ".mesh"
+    a = "a3f28b4c-1234-5678-9abc-def012345678"
+    b = "b7c12d9f-abcd-ef01-2345-678901234567"
+    result = resolve_channel(mesh_dir=mesh_dir, participants=[a, b])
+    expected_xor = xor_uuids([a, b])
+    assert result["channel_dir"] == str(mesh_dir / "channels" / expected_xor)
+    assert result["attachments_dir"] == str(
+        mesh_dir / "channels" / expected_xor / "attachments"
+    )
+
+
+def test_inv6_resolve_creates_directory(tmp_path):  # Tests CH-INV-6
+    """resolve_channel lazily creates the channel directory."""
+    mesh_dir = tmp_path / ".mesh"
+    a = "a3f28b4c-1234-5678-9abc-def012345678"
+    b = "b7c12d9f-abcd-ef01-2345-678901234567"
+    resolve_channel(mesh_dir=mesh_dir, participants=[a, b])
+    expected_xor = xor_uuids([a, b])
+    assert (mesh_dir / "channels" / expected_xor).is_dir()
+    assert (mesh_dir / "channels" / expected_xor / "attachments").is_dir()
+
+
+def test_fail1_resolve_rejects_single_participant(tmp_path):  # Tests CH-FAIL-1
+    """resolve_channel with fewer than 2 participants raises ValueError."""
+    mesh_dir = tmp_path / ".mesh"
+    with pytest.raises(ValueError, match="at least 2 participants"):
+        resolve_channel(mesh_dir=mesh_dir, participants=["only-one"])
+
+
+def test_resolve_idempotent(tmp_path):
+    """Calling resolve_channel twice returns the same result, no error."""
+    mesh_dir = tmp_path / ".mesh"
+    a = "a3f28b4c-1234-5678-9abc-def012345678"
+    b = "b7c12d9f-abcd-ef01-2345-678901234567"
+    r1 = resolve_channel(mesh_dir=mesh_dir, participants=[a, b])
+    r2 = resolve_channel(mesh_dir=mesh_dir, participants=[a, b])
+    assert r1 == r2

--- a/channels/tests/test_xor.py
+++ b/channels/tests/test_xor.py
@@ -1,0 +1,47 @@
+"""Tests for XOR channel computation."""
+
+import uuid as uuid_mod
+
+from channels.xor import xor_uuids
+
+
+def test_inv1_xor_symmetric():  # Tests CH-INV-1
+    """XOR(A, B) == XOR(B, A)."""
+    a = str(uuid_mod.uuid4())
+    b = str(uuid_mod.uuid4())
+    assert xor_uuids([a, b]) == xor_uuids([b, a])
+
+
+def test_inv2_xor_associative():  # Tests CH-INV-2
+    """XOR(A, B, C) == XOR(sorted([A, B, C])) regardless of input order."""
+    a = str(uuid_mod.uuid4())
+    b = str(uuid_mod.uuid4())
+    c = str(uuid_mod.uuid4())
+    assert xor_uuids([a, b, c]) == xor_uuids([c, a, b])
+    assert xor_uuids([a, b, c]) == xor_uuids([b, c, a])
+
+
+def test_inv3_xor_produces_valid_uuid():  # Tests CH-INV-3
+    """XOR result is a valid UUID string (8-4-4-4-12 hex format)."""
+    a = "a3f28b4c-1234-5678-9abc-def012345678"
+    b = "b7c12d9f-abcd-ef01-2345-678901234567"
+    result = xor_uuids([a, b])
+    parsed = uuid_mod.UUID(result)
+    assert str(parsed) == result
+
+
+def test_xor_deterministic():
+    """Same inputs always produce the same output."""
+    a = "a3f28b4c-1234-5678-9abc-def012345678"
+    b = "b7c12d9f-abcd-ef01-2345-678901234567"
+    r1 = xor_uuids([a, b])
+    r2 = xor_uuids([a, b])
+    assert r1 == r2
+
+
+def test_xor_known_values():
+    """XOR of known UUIDs produces the expected result."""
+    a = "00000000-0000-0000-0000-000000000001"
+    b = "00000000-0000-0000-0000-000000000002"
+    result = xor_uuids([a, b])
+    assert result == "00000000-0000-0000-0000-000000000003"

--- a/channels/uv.lock
+++ b/channels/uv.lock
@@ -1,0 +1,79 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "channels"
+version = "0.4.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ For protocol details, see [DESIGN.md](DESIGN.md).
 | [mesh-server](../mesh-server/) | Message routing, agent lifecycle, event store | v0.2 | [SPEC.md](../mesh-server/SPEC.md) |
 | [controller-ui](../mesh-server/src/mesh_server/static/) | Web UI for human controller | v0.3 | — |
 | [agent-runtime](../agent-runtime/) | Agent bootstrap and lifecycle management | v0.3 | [SPEC.md](../agent-runtime/SPEC.md) |
-| channels | XOR-derived filesystem channels | Planned | — |
+| [channels](../channels/) | XOR-derived filesystem channels for attachments | v0.4 | [SPEC.md](../channels/SPEC.md) |
 
 ## Technology Stack
 
@@ -172,6 +172,14 @@ In the context of needing spawn_neighbor to launch real Claude CLI processes, fa
 The supervisor writes config artifacts (MCP config, hooks, CLAUDE.md, settings.json) to the agent's directory, launches `claude` as a subprocess, and monitors it. If an agent process exits unexpectedly, the supervisor emits an AgentDeregistered event automatically.
 
 Spawned agents inherit the parent process environment, including Claude Code subscription credentials — no API key is required.
+
+## Channel Resolution
+
+In the context of agents needing to exchange files (screenshots, code, reports) without routing binary data through the MCP message bus, facing the choice between server-mediated file transfer or direct filesystem access, we decided to use XOR-derived directory paths that both parties compute independently, accepting that agents must have shared filesystem access (true for single-machine deployments).
+
+Channel directories live under `.mesh/channels/<xor-uuid>/attachments/`. The XOR of sorted participant UUIDs (as 128-bit integers) produces a full UUID used as the directory name. The well-known `.mesh/channels/all/` directory serves broadcast file sharing.
+
+Agents write files to the channel directory, then reference them via attachment descriptors in `send()`. Recipients read the file paths from their inbox. The server validates descriptors but does not intermediate file I/O.
 
 ## Further Reading
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -14,7 +14,7 @@ The mesh consists of three layers: agents (Claude CLI instances or any MCP-capab
 
 For subsystem boundaries and technology decisions, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
-## Tool API (6 Tools)
+## Tool API (7 Tools)
 
 ![Tool API](images/04-tool-api.svg)
 
@@ -31,9 +31,9 @@ Returns queued messages addressed to the calling agent. Drains the inbox — ret
 - `block=false` (default) — returns immediately, possibly empty. Agent continues working.
 - `block=true` — holds until at least one message arrives. This is how an agent goes idle and yields execution.
 
-### 3. `send(caller_uuid, to, message?, command?)`
+### 3. `send(caller_uuid, to, message?, command?, attachments?)`
 
-Sends a message to one or more recipients.
+Sends a message to one or more recipients. The optional `attachments` parameter is a list of attachment descriptors. Each descriptor must include a `type` field. File-reference attachments include a `path` field (relative to the channel's `attachments/` directory). Inline attachments include a `data` field.
 
 | `to` value | Behavior |
 |---|---|
@@ -60,6 +60,14 @@ Registers a new agent in the mesh. Generates credentials (UUID, bearer token) an
 ### 6. `shutdown(caller_uuid)`
 
 Agent self-terminates. The server emits an `AgentDeregistered` event and marks the agent as dead. The controller can also shut down any agent.
+
+### 7. `resolve_channel(caller_uuid, participants) -> {channel_dir, attachments_dir}`
+
+Returns the absolute path to the channel directory for a set of participants. Creates the directory if it doesn't exist. Agents call this before writing files to know where to place them.
+
+- `participants` must contain at least one UUID besides the caller
+- Broadcast UUID resolves to `.mesh/channels/all/`
+- Dead agent UUIDs are allowed — channels outlive agents
 
 ## Message Schema
 
@@ -366,6 +374,7 @@ The original design identified 8 open questions. Here are the resolutions adopte
 
 ## Future Work
 
-The controller-ui and agent-runtime subsystems are now implemented in v0.2. The remaining planned subsystem:
+All four planned subsystems (mesh-server, controller-ui, agent-runtime, channels) are now implemented. Remaining areas:
 
-- **channels** — XOR-derived filesystem channels for attachments and shared artifacts. Manages directory creation, cleanup policies, and access patterns for the `.mesh/channels/` tree.
+- **REST API authentication** — REST endpoints currently have no authentication; the system works without it in single-machine deployments
+- **Backpressure** — inboxes can grow without bound; not a practical concern at current mesh sizes

--- a/mesh-server/SPEC.md
+++ b/mesh-server/SPEC.md
@@ -11,11 +11,12 @@ Event-sourced MCP server for message-passing between agent instances. Singleton 
 | Tool | Description |
 |---|---|
 | `whoami(caller_uuid)` | Returns agent's UUID and neighbor count |
-| `send(caller_uuid, to, message?, command?)` | Send message to agent(s) or broadcast |
+| `send(caller_uuid, to, message?, command?, attachments?)` | Send message to agent(s) or broadcast |
 | `read_inbox(caller_uuid, block?)` | Drain inbox; block=true yields until message |
 | `show_neighbors(caller_uuid)` | List all registered agents |
 | `spawn_neighbor(caller_uuid, claude_md?, model?, thinking_budget?)` | Register new agent, prepare credentials |
 | `shutdown(caller_uuid)` | Self-terminate, deregister from mesh |
+| `resolve_channel(caller_uuid, participants)` | Resolve XOR-derived channel directory path |
 
 ### REST/SSE API (controller web UI)
 
@@ -71,6 +72,11 @@ Event-sourced MCP server for message-passing between agent instances. Singleton 
 - **INV-29**: REST /api/spawn launches Claude CLI subprocess via AgentSupervisor
 - **INV-30**: Supervisor emits AgentDeregistered when process exits unexpectedly
 - **INV-31**: Mock CLI agent completes full spawn→connect→message→shutdown cycle
+- **INV-32**: send with attachments stores descriptors in MessageEnqueued event
+- **INV-33**: read_inbox returns attachments with resolved absolute paths
+- **INV-34**: resolve_channel returns correct XOR-derived path for participant set
+- **INV-35**: resolve_channel creates directory on first call
+- **INV-36**: Old events without attachments field replay with None default
 
 ## Failure Modes
 
@@ -80,13 +86,17 @@ Event-sourced MCP server for message-passing between agent instances. Singleton 
 - **FAIL-4**: Duplicate UUID registration (astronomically unlikely with UUIDv4)
 - **FAIL-5**: Invalid model string returns error
 - **FAIL-6**: Invalid thinking_budget (< 1024) returns error
+- **FAIL-7**: send rejects attachments that are not a list
+- **FAIL-8**: send rejects attachment descriptor missing 'type' field
+- **FAIL-9**: send rejects attachment path containing '..' (path traversal)
+- **FAIL-10**: resolve_channel with no other participants returns invalid_args
 
 ## Event Model
 
 ```
 AgentRegistered(uuid, token_hash, pid, timestamp)
 AgentDeregistered(uuid, reason, timestamp)
-MessageEnqueued(id, from_uuid, to_uuid, command?, message?, timestamp)
+MessageEnqueued(id, from_uuid, to_uuid, command?, message?, timestamp, attachments?)
 MessageDrained(message_id, by_uuid, timestamp)
 ```
 

--- a/mesh-server/pyproject.toml
+++ b/mesh-server/pyproject.toml
@@ -5,6 +5,7 @@ description = "MCP Mesh Server — event-sourced message-passing actor system"
 requires-python = ">=3.13"
 dependencies = [
     "agent-runtime",
+    "channels",
     "mcp[cli]>=1.2.0",
     "uvicorn>=0.30",
 ]
@@ -25,6 +26,7 @@ packages = ["src/mesh_server"]
 
 [tool.uv.sources]
 agent-runtime = { path = "../agent-runtime" }
+channels = { path = "../channels" }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/mesh-server/src/mesh_server/api.py
+++ b/mesh-server/src/mesh_server/api.py
@@ -120,6 +120,7 @@ def create_api_routes(
             to=to,
             message=body.get("message"),
             command=body.get("command"),
+            attachments=body.get("attachments"),
         )
         if result.get("code") == "not_found":
             return JSONResponse(result, status_code=404)
@@ -185,7 +186,9 @@ def create_api_routes(
 
     async def api_inbox(request: Request) -> Response:
         """Return controller's inbox messages."""
-        result = tool_read_inbox(state, store, caller_uuid=controller_uuid)
+        result = tool_read_inbox(
+            state, store, caller_uuid=controller_uuid, mesh_dir=mesh_dir
+        )
         return JSONResponse(result)
 
     async def index(request: Request) -> Response:

--- a/mesh-server/src/mesh_server/attachments.py
+++ b/mesh-server/src/mesh_server/attachments.py
@@ -1,0 +1,69 @@
+"""Attachment validation and path resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+from channels import resolve_channel
+
+
+def validate_attachments(attachments: list | None) -> str | None:
+    """Validate attachment descriptors. Returns error string or None if valid."""
+    if attachments is None:
+        return None
+
+    if not isinstance(attachments, list):
+        return "attachments must be a list"
+
+    for att in attachments:
+        if not isinstance(att, dict):
+            return "each attachment must be a dict"
+        if "type" not in att:
+            return "attachment missing 'type' field"
+        if "path" in att:
+            path = att["path"]
+            if ".." in PurePosixPath(path).parts:
+                return f"path traversal not allowed: {path}"
+
+    return None
+
+
+def normalize_attachments(attachments: list | None) -> list | None:
+    """Normalize attachments: empty list becomes None."""
+    if not attachments:
+        return None
+    return attachments
+
+
+def resolve_attachment_paths(
+    attachments: list[dict] | None,
+    *,
+    from_uuid: str,
+    to_uuid: str,
+    mesh_dir: Path,
+) -> list[dict] | None:
+    """Resolve relative attachment paths to absolute paths.
+
+    For file-ref attachments (those with a 'path' field), resolves
+    the path relative to the channel's attachments/ directory.
+    Inline attachments (those with 'data' field) are returned as-is.
+    """
+    if not attachments:
+        return attachments
+
+    channel = resolve_channel(
+        mesh_dir=mesh_dir,
+        participants=sorted([from_uuid, to_uuid]),
+    )
+    attachments_dir = Path(channel["attachments_dir"])
+
+    resolved = []
+    for att in attachments:
+        if "path" in att:
+            resolved.append({
+                **att,
+                "path": str(attachments_dir / att["path"]),
+            })
+        else:
+            resolved.append(att)
+    return resolved

--- a/mesh-server/src/mesh_server/attachments.py
+++ b/mesh-server/src/mesh_server/attachments.py
@@ -60,10 +60,12 @@ def resolve_attachment_paths(
     resolved = []
     for att in attachments:
         if "path" in att:
-            resolved.append({
-                **att,
-                "path": str(attachments_dir / att["path"]),
-            })
+            resolved.append(
+                {
+                    **att,
+                    "path": str(attachments_dir / att["path"]),
+                }
+            )
         else:
             resolved.append(att)
     return resolved

--- a/mesh-server/src/mesh_server/projections.py
+++ b/mesh-server/src/mesh_server/projections.py
@@ -69,6 +69,7 @@ class MeshState:
             command=event.command,
             message=event.message,
             timestamp=event.timestamp,
+            attachments=event.attachments,
         )
         self._inboxes.setdefault(event.to_uuid, []).append(msg)
         # Signal waiter if agent is blocked on read_inbox

--- a/mesh-server/src/mesh_server/server.py
+++ b/mesh-server/src/mesh_server/server.py
@@ -20,6 +20,7 @@ from mesh_server.projections import MeshState
 from mesh_server.spawner import prepare_spawn
 from mesh_server.tools import (
     tool_read_inbox_async,
+    tool_resolve_channel,
     tool_send,
     tool_show_neighbors,
     tool_shutdown,
@@ -120,6 +121,7 @@ async def send(
     ctx: Ctx,
     message: str | None = None,
     command: str | None = None,
+    attachments: list | None = None,
 ) -> dict:
     """Send a message to another agent or broadcast.
 
@@ -128,6 +130,7 @@ async def send(
         to: Recipient UUID, or "00000000-0000-0000-0000-000000000000" for broadcast
         message: Free-form message text
         command: Optional structured command string
+        attachments: Optional list of attachment descriptors (each must have a 'type' field)
     """
     app = _get_app(ctx)
     agent = app.state.get_agent(caller_uuid)
@@ -140,6 +143,7 @@ async def send(
         to=to,
         message=message,
         command=command,
+        attachments=attachments,
     )
 
 
@@ -161,6 +165,7 @@ async def read_inbox(
         app.store,
         caller_uuid=caller_uuid,
         block=block,
+        mesh_dir=app.mesh_dir,
     )
 
 
@@ -184,6 +189,26 @@ async def shutdown(caller_uuid: str, ctx: Ctx) -> dict:
     """
     app = _get_app(ctx)
     return tool_shutdown(app.state, app.store, caller_uuid=caller_uuid)
+
+
+@mcp.tool()
+async def resolve_channel(
+    caller_uuid: str,
+    participants: list[str],
+    ctx: Ctx,
+) -> dict:
+    """Resolve the shared channel directory for exchanging files with other agents.
+
+    Args:
+        caller_uuid: Your agent UUID (from MESH_AGENT_ID env var)
+        participants: List of other agent UUIDs to share the channel with
+    """
+    app = _get_app(ctx)
+    return tool_resolve_channel(
+        mesh_dir=app.mesh_dir,
+        caller_uuid=caller_uuid,
+        participants=participants,
+    )
 
 
 @mcp.tool()

--- a/mesh-server/src/mesh_server/tools.py
+++ b/mesh-server/src/mesh_server/tools.py
@@ -8,7 +8,15 @@ from __future__ import annotations
 
 import time
 import uuid as uuid_mod
+from pathlib import Path
 
+from channels import resolve_channel as channels_resolve
+
+from mesh_server.attachments import (
+    normalize_attachments,
+    resolve_attachment_paths,
+    validate_attachments,
+)
 from mesh_server.events import EventStore
 from mesh_server.projections import MeshState
 from mesh_server.types import (
@@ -40,8 +48,17 @@ def tool_send(
     to: str | list[str],
     message: str | None = None,
     command: str | None = None,
+    attachments: list | None = None,
 ) -> dict:
     """Send a message to one or more recipients."""
+    # Validate attachments
+    err = validate_attachments(attachments)
+    if err:
+        return _result("invalid_args", error=err)
+
+    # Normalize: empty list -> None
+    attachments = normalize_attachments(attachments)
+
     # Normalize to a list of recipient UUIDs
     if isinstance(to, str):
         if to == BROADCAST_UUID:
@@ -70,6 +87,7 @@ def tool_send(
             command=command,
             message=message,
             timestamp=time.time(),
+            attachments=attachments,
         )
         store.append(event)
         state.apply(event)
@@ -78,12 +96,36 @@ def tool_send(
     return _result("ok", {"delivered_to": delivered_to})
 
 
+def _format_message(msg: "Message", *, mesh_dir: Path | None = None) -> dict:
+    """Format a Message for tool output, optionally resolving attachment paths."""
+    attachments = msg.attachments
+    if attachments and mesh_dir is not None:
+        attachments = resolve_attachment_paths(
+            attachments,
+            from_uuid=msg.from_uuid,
+            to_uuid=msg.to_uuid,
+            mesh_dir=mesh_dir,
+        )
+    result = {
+        "id": msg.id,
+        "from": msg.from_uuid,
+        "to": msg.to_uuid,
+        "command": msg.command,
+        "message": msg.message,
+        "timestamp": msg.timestamp,
+    }
+    if attachments:
+        result["attachments"] = attachments
+    return result
+
+
 def tool_read_inbox(
     state: MeshState,
     store: EventStore,
     *,
     caller_uuid: str,
     block: bool = False,
+    mesh_dir: Path | None = None,
 ) -> dict:
     """Read and drain inbox (non-blocking version)."""
     messages = state.get_inbox(caller_uuid)
@@ -99,15 +141,7 @@ def tool_read_inbox(
         "ok",
         {
             "messages": [
-                {
-                    "id": m.id,
-                    "from": m.from_uuid,
-                    "to": m.to_uuid,
-                    "command": m.command,
-                    "message": m.message,
-                    "timestamp": m.timestamp,
-                }
-                for m in messages
+                _format_message(m, mesh_dir=mesh_dir) for m in messages
             ]
         },
     )
@@ -119,6 +153,7 @@ async def tool_read_inbox_async(
     *,
     caller_uuid: str,
     block: bool = False,
+    mesh_dir: Path | None = None,
 ) -> dict:
     """Read and drain inbox. If block=True, waits indefinitely for a message."""
     if block:
@@ -132,7 +167,9 @@ async def tool_read_inbox_async(
                 state.clear_waiter(caller_uuid)
 
     # Now drain (whether we waited or not)
-    return tool_read_inbox(state, store, caller_uuid=caller_uuid, block=False)
+    return tool_read_inbox(
+        state, store, caller_uuid=caller_uuid, block=False, mesh_dir=mesh_dir
+    )
 
 
 def tool_show_neighbors(state: MeshState, *, caller_uuid: str) -> dict:
@@ -171,3 +208,20 @@ def tool_shutdown(
     store.append(event)
     state.apply(event)
     return _result("ok")
+
+
+def tool_resolve_channel(
+    *,
+    mesh_dir: Path,
+    caller_uuid: str,
+    participants: list[str],
+) -> dict:
+    """Resolve channel directory for a set of participants."""
+    all_participants = sorted(set([caller_uuid] + participants))
+    if len(all_participants) < 2:
+        return _result("invalid_args", error="Need at least one other participant")
+    try:
+        result = channels_resolve(mesh_dir=mesh_dir, participants=all_participants)
+        return _result("ok", result)
+    except ValueError as e:
+        return _result("invalid_args", error=str(e))

--- a/mesh-server/src/mesh_server/tools.py
+++ b/mesh-server/src/mesh_server/tools.py
@@ -22,6 +22,7 @@ from mesh_server.projections import MeshState
 from mesh_server.types import (
     BROADCAST_UUID,
     AgentDeregistered,
+    Message,
     MessageDrained,
     MessageEnqueued,
 )

--- a/mesh-server/src/mesh_server/tools.py
+++ b/mesh-server/src/mesh_server/tools.py
@@ -140,11 +140,7 @@ def tool_read_inbox(
 
     return _result(
         "ok",
-        {
-            "messages": [
-                _format_message(m, mesh_dir=mesh_dir) for m in messages
-            ]
-        },
+        {"messages": [_format_message(m, mesh_dir=mesh_dir) for m in messages]},
     )
 
 

--- a/mesh-server/src/mesh_server/types.py
+++ b/mesh-server/src/mesh_server/types.py
@@ -91,6 +91,7 @@ class MessageEnqueued:
     command: str | None
     message: str | None
     timestamp: float
+    attachments: list[dict] | None = None
     type: str = field(default="MessageEnqueued", init=False)
 
 
@@ -116,6 +117,7 @@ class Message:
     command: str | None
     message: str | None
     timestamp: float
+    attachments: list[dict] | None = None
 
 
 @dataclass

--- a/mesh-server/tests/test_events.py
+++ b/mesh-server/tests/test_events.py
@@ -211,15 +211,17 @@ async def test_inv19_full_queue_skipped(event_log):
 def test_inv36_replay_without_attachments(event_log):  # Tests INV-36
     """INV-36: Old events without attachments replay with None default."""
     # Write a MessageEnqueued event WITHOUT the attachments field (simulates old data)
-    old_event_json = json.dumps({
-        "type": "MessageEnqueued",
-        "id": "msg-old",
-        "from_uuid": "agent-1",
-        "to_uuid": "agent-2",
-        "command": None,
-        "message": "legacy message",
-        "timestamp": time.time(),
-    })
+    old_event_json = json.dumps(
+        {
+            "type": "MessageEnqueued",
+            "id": "msg-old",
+            "from_uuid": "agent-1",
+            "to_uuid": "agent-2",
+            "command": None,
+            "message": "legacy message",
+            "timestamp": time.time(),
+        }
+    )
     event_log.path.parent.mkdir(parents=True, exist_ok=True)
     with open(event_log.path, "w") as f:
         f.write(old_event_json + "\n")

--- a/mesh-server/tests/test_events.py
+++ b/mesh-server/tests/test_events.py
@@ -206,3 +206,26 @@ async def test_inv19_full_queue_skipped(event_log):
     assert queue.get_nowait().uuid == "first"
 
     event_log.unsubscribe(queue)
+
+
+def test_inv36_replay_without_attachments(event_log):  # Tests INV-36
+    """INV-36: Old events without attachments replay with None default."""
+    # Write a MessageEnqueued event WITHOUT the attachments field (simulates old data)
+    old_event_json = json.dumps({
+        "type": "MessageEnqueued",
+        "id": "msg-old",
+        "from_uuid": "agent-1",
+        "to_uuid": "agent-2",
+        "command": None,
+        "message": "legacy message",
+        "timestamp": time.time(),
+    })
+    event_log.path.parent.mkdir(parents=True, exist_ok=True)
+    with open(event_log.path, "w") as f:
+        f.write(old_event_json + "\n")
+
+    events = event_log.replay()
+    assert len(events) == 1
+    assert isinstance(events[0], MessageEnqueued)
+    assert events[0].message == "legacy message"
+    assert events[0].attachments is None

--- a/mesh-server/tests/test_tools.py
+++ b/mesh-server/tests/test_tools.py
@@ -13,6 +13,7 @@ from mesh_server.events import EventStore
 from mesh_server.tools import (
     tool_read_inbox,
     tool_read_inbox_async,
+    tool_resolve_channel,
     tool_send,
     tool_show_neighbors,
     tool_shutdown,
@@ -154,3 +155,164 @@ def test_read_inbox_empty_nonblocking(state, store):
     result = tool_read_inbox(state, store, caller_uuid="agent-1", block=False)
     assert result["code"] == "ok"
     assert result["data"]["messages"] == []
+
+
+# --- Attachment tests ---
+
+
+def test_inv32_send_stores_attachments(state, store):  # Tests INV-32
+    _register(state, store, "agent-1")
+    _register(state, store, "agent-2")
+    atts = [{"type": "file-ref", "path": "report.pdf"}]
+    result = tool_send(
+        state,
+        store,
+        caller_uuid="agent-1",
+        to="agent-2",
+        message="see attached",
+        attachments=atts,
+    )
+    assert result["code"] == "ok"
+    inbox = state.get_inbox("agent-2")
+    assert len(inbox) == 1
+    assert inbox[0].attachments == atts
+
+
+def test_inv32_send_without_attachments(state, store):  # Tests INV-32 (no attachments)
+    _register(state, store, "agent-1")
+    _register(state, store, "agent-2")
+    result = tool_send(
+        state, store, caller_uuid="agent-1", to="agent-2", message="plain"
+    )
+    assert result["code"] == "ok"
+    inbox = state.get_inbox("agent-2")
+    assert inbox[0].attachments is None
+
+
+def test_inv32_send_empty_attachments_treated_as_none(state, store):  # Tests INV-32
+    _register(state, store, "agent-1")
+    _register(state, store, "agent-2")
+    result = tool_send(
+        state,
+        store,
+        caller_uuid="agent-1",
+        to="agent-2",
+        message="empty list",
+        attachments=[],
+    )
+    assert result["code"] == "ok"
+    inbox = state.get_inbox("agent-2")
+    assert inbox[0].attachments is None
+
+
+_UUID_A = "11111111-1111-1111-1111-111111111111"
+_UUID_B = "22222222-2222-2222-2222-222222222222"
+
+
+def test_inv33_read_inbox_returns_attachments(state, store, tmp_path):  # Tests INV-33
+    mesh_dir = tmp_path / ".mesh"
+    _register(state, store, _UUID_A)
+    _register(state, store, _UUID_B)
+    atts = [{"type": "file-ref", "path": "data.csv"}]
+    tool_send(
+        state,
+        store,
+        caller_uuid=_UUID_A,
+        to=_UUID_B,
+        message="check file",
+        attachments=atts,
+    )
+    result = tool_read_inbox(
+        state, store, caller_uuid=_UUID_B, block=False, mesh_dir=mesh_dir
+    )
+    assert result["code"] == "ok"
+    msg = result["data"]["messages"][0]
+    assert "attachments" in msg
+    resolved_path = msg["attachments"][0]["path"]
+    # Path should be absolute and contain the mesh_dir
+    assert str(mesh_dir) in resolved_path
+    assert resolved_path.endswith("data.csv")
+
+
+def test_inv34_resolve_channel_returns_path(tmp_path):  # Tests INV-34
+    mesh_dir = tmp_path / ".mesh"
+    result = tool_resolve_channel(
+        mesh_dir=mesh_dir,
+        caller_uuid=_UUID_A,
+        participants=[_UUID_B],
+    )
+    assert result["code"] == "ok"
+    assert "channel_dir" in result["data"]
+    assert "attachments_dir" in result["data"]
+    assert str(mesh_dir) in result["data"]["channel_dir"]
+
+
+def test_inv35_resolve_channel_creates_dir(tmp_path):  # Tests INV-35
+    mesh_dir = tmp_path / ".mesh"
+    result = tool_resolve_channel(
+        mesh_dir=mesh_dir,
+        caller_uuid=_UUID_A,
+        participants=[_UUID_B],
+    )
+    from pathlib import Path
+
+    channel_dir = Path(result["data"]["channel_dir"])
+    attachments_dir = Path(result["data"]["attachments_dir"])
+    assert channel_dir.is_dir()
+    assert attachments_dir.is_dir()
+
+
+def test_fail7_send_rejects_non_list_attachments(state, store):  # Tests FAIL-7
+    _register(state, store, "agent-1")
+    _register(state, store, "agent-2")
+    result = tool_send(
+        state,
+        store,
+        caller_uuid="agent-1",
+        to="agent-2",
+        message="bad",
+        attachments="not-a-list",
+    )
+    assert result["code"] == "invalid_args"
+    assert "list" in result["error"]
+
+
+def test_fail8_send_rejects_attachment_missing_type(state, store):  # Tests FAIL-8
+    _register(state, store, "agent-1")
+    _register(state, store, "agent-2")
+    result = tool_send(
+        state,
+        store,
+        caller_uuid="agent-1",
+        to="agent-2",
+        message="bad",
+        attachments=[{"path": "file.txt"}],
+    )
+    assert result["code"] == "invalid_args"
+    assert "type" in result["error"]
+
+
+def test_fail9_send_rejects_path_traversal(state, store):  # Tests FAIL-9
+    _register(state, store, "agent-1")
+    _register(state, store, "agent-2")
+    result = tool_send(
+        state,
+        store,
+        caller_uuid="agent-1",
+        to="agent-2",
+        message="bad",
+        attachments=[{"type": "file-ref", "path": "../../../etc/passwd"}],
+    )
+    assert result["code"] == "invalid_args"
+    assert "traversal" in result["error"]
+
+
+def test_fail10_resolve_channel_rejects_single(tmp_path):  # Tests FAIL-10
+    mesh_dir = tmp_path / ".mesh"
+    result = tool_resolve_channel(
+        mesh_dir=mesh_dir,
+        caller_uuid="agent-1",
+        participants=[],
+    )
+    assert result["code"] == "invalid_args"
+    assert "participant" in result["error"].lower()

--- a/mesh-server/uv.lock
+++ b/mesh-server/uv.lock
@@ -109,6 +109,16 @@ wheels = [
 ]
 
 [[package]]
+name = "channels"
+version = "0.4.0"
+source = { directory = "../channels" }
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -331,6 +341,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-runtime" },
+    { name = "channels" },
     { name = "mcp", extra = ["cli"] },
     { name = "uvicorn" },
 ]
@@ -345,6 +356,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agent-runtime", directory = "../agent-runtime" },
+    { name = "channels", directory = "../channels" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
## Summary

- New `channels/` subsystem: XOR-derived filesystem directories for file exchange between agents
- New `resolve_channel` MCP tool (#7): agents call this to discover their shared channel directory before writing files
- `send()` now accepts optional `attachments` parameter with typed descriptors (inline markdown, file refs)
- `read_inbox()` returns attachments with resolved absolute paths
- Attachment validation: `type` field required, path traversal (`..`) rejected
- Backward-compatible: old events without `attachments` field replay cleanly

## Test Plan

- [x] 11 channels/ unit tests: XOR symmetry, associativity, valid UUID output, broadcast path, directory creation, idempotency
- [x] 11 mesh-server tests: attachments round-trip send→inbox, resolve_channel tool, event replay backward compat, validation (non-list, missing type, path traversal)
- [x] 104 total tests across all packages, 0 regressions
- [x] ruff check + ruff format clean
- [x] Documentation updated: README.md, ARCHITECTURE.md, DESIGN.md, mesh-server/SPEC.md, new channels/SPEC.md

<details><summary>Design Document</summary>

## Scope

Add the `channels` subsystem — the last planned subsystem in MCP Mesh. Provides deterministic, XOR-derived filesystem directories where agents exchange files.

**Architecture:** `channel_id = XOR(sorted(participant_uuids))` — each UUID parsed as 128-bit integer, XORed, formatted as full UUID string. Broadcast UUID resolves to well-known `all/` directory.

**File transfer model:** Server does NOT intermediate file I/O. Agents write files to channel dir, reference them via attachment descriptors in `send()`, recipients read files directly from resolved paths.

**Subsystem boundaries:** `channels/` package is standalone (no mesh-server imports). `mesh-server` integrates via dependency, adding `attachments` to events and a `resolve_channel` tool that delegates to the channels package.

**Error handling:** Attachment validation at API boundary (type required, path traversal rejected). Channel dirs preserved after agent shutdown. Dead agent UUIDs allowed in resolve_channel.

</details>

Closes #22