### PR TITLE
fix: handle squash-merge commit messages in tag-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,9 @@ jobs:
       - name: Extract version and tag
         id: version
         run: |
-          VERSION=$(echo "${{ github.event.head_commit.message }}" | sed 's/release: //')
+          # Use only first line; strip PR suffix like "(#25)" from squash merges
+          FIRST_LINE=$(echo "${{ github.event.head_commit.message }}" | head -n1)
+          VERSION=$(echo "$FIRST_LINE" | sed 's/release: //; s/ (#[0-9]*)$//')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           TAG="$(date -u +%Y-%m-%dT%H%M%SZ)"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- **Root cause:** `tag-release` job used full `head_commit.message` which includes multi-line squash merge content (PR suffix, co-author trailers). Multi-line value broke `GITHUB_OUTPUT` parsing.
- **Fix:** extract only first line of commit message, strip PR number suffix `(#N)`.

## Test plan
- [ ] Merge this PR — the resulting push starts with `release:` so the `release-pr` job skips (no `## Unreleased`)
- [ ] Manually verify the `tag-release` job would parse correctly by checking the commit message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)